### PR TITLE
Added reify for Documentation node and updated metamodel

### DIFF
--- a/APIAddIn/APIAddIn/APIAddinClass.cs
+++ b/APIAddIn/APIAddIn/APIAddinClass.cs
@@ -86,6 +86,7 @@ namespace APIAddIn
         public static string METAMODEL_RESPONSE = "Response";
         public static string METAMODEL_RESOURCE = "Resource";
         public static string METAMODEL_RESOURCETYPE = "ResourceType";
+        public static string METAMODEL_DOCUMENTATION = "Documentation";
         public static string METAMODEL_ITEMGET = "ItemGet";
         public static string METAMODEL_SECURITYSCHEME = "SecurityScheme";
         public static string METAMODEL_QUERY_PARAMETER = "QueryParameter";

--- a/APIAddIn/APIAddIn/APIAddinClass.cs
+++ b/APIAddIn/APIAddIn/APIAddinClass.cs
@@ -87,6 +87,7 @@ namespace APIAddIn
         public static string METAMODEL_RESOURCE = "Resource";
         public static string METAMODEL_RESOURCETYPE = "ResourceType";
         public static string METAMODEL_DOCUMENTATION = "Documentation";
+        public static string METAMODEL_METHOD_TRAITS = "MethodTraits";
         public static string METAMODEL_ITEMGET = "ItemGet";
         public static string METAMODEL_SECURITYSCHEME = "SecurityScheme";
         public static string METAMODEL_QUERY_PARAMETER = "QueryParameter";

--- a/APIAddIn/APIAddIn/MetaDataManager.cs
+++ b/APIAddIn/APIAddIn/MetaDataManager.cs
@@ -145,7 +145,12 @@ namespace APIAddIn
                 return true;
             return false;
         }
-
+        public static bool filterDocumentation(EA.Repository Repository, EA.Connector con, EA.Element e, EA.Element classifier)
+        {
+            if (classifier != null && classifier.Name.Equals(APIAddIn.APIAddinClass.METAMODEL_DOCUMENTATION))
+                return true;
+            return false;
+        }
         public static bool filterSecurity(EA.Repository Repository, EA.Connector con, EA.Element e, EA.Element classifier)
         {
             if (classifier == null)

--- a/APIAddIn/APIAddIn/MetaDataManager.cs
+++ b/APIAddIn/APIAddIn/MetaDataManager.cs
@@ -151,6 +151,12 @@ namespace APIAddIn
                 return true;
             return false;
         }
+        public static bool filterMethodTraits(EA.Repository Repository, EA.Connector con, EA.Element e, EA.Element classifier)
+        {
+            if (classifier != null && classifier.Name.Equals(APIAddIn.APIAddinClass.METAMODEL_METHOD_TRAITS))
+                return true;
+            return false;
+        }
         public static bool filterSecurity(EA.Repository Repository, EA.Connector con, EA.Element e, EA.Element classifier)
         {
             if (classifier == null)


### PR DESCRIPTION
To make the API definition more explicit I've changed the documentation section of the API export to use a new Documentation node in the meta model. Also found an error in the way I did the Security reify and now the 'type' is an attribute.

Here's the updated meta model:
![metamodel](https://cloud.githubusercontent.com/assets/298725/25410506/3fd8fad2-2a6b-11e7-854b-c7ec6df70fec.png)

Here's a sample API:
![sample api](https://cloud.githubusercontent.com/assets/298725/25410514/485106f0-2a6b-11e7-9299-67408e3abd09.png)
